### PR TITLE
Fix: Configure GitHub Pages deployment and update homepage URL

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -43,14 +43,19 @@ jobs:
       - name: Build application
         run: npm run build
 
+      - name: Verify Build Output
+        run: ls -R dist/
+
       - name: Prepare artifact directory
         run: |
+          rm -rf gh-pages-artifact
           mkdir -p gh-pages-artifact/dist
           cp public/index.html gh-pages-artifact/index.html
-          cp -r dist/* gh-pages-artifact/dist/
-          # If there are other static assets in public, copy them too. e.g.:
-          # cp public/favicon.ico gh-pages-artifact/
-          # cp public/manifest.json gh-pages-artifact/
+          # Add any other specific assets from public if they were intended to be at the root
+          # For example: cp public/favicon.ico gh-pages-artifact/
+          cp dist/bundle.js gh-pages-artifact/dist/bundle.js 
+          echo "Artifact directory structure:"
+          ls -R gh-pages-artifact
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/ShegosThato/site/issues"
   },
-  "homepage": "https://github.com/ShegosThato/site#readme",
+  "homepage": "https://ShegosThato.github.io/site/",
   "dependencies": {
     "prop-types": "^15.8.1",
     "react": "^19.1.0",


### PR DESCRIPTION
This commit addresses a 404 error on the deployed GitHub Pages site.

Changes include:
- Updated the `homepage` field in `package.json` to the correct GitHub Pages URL (https://ShegosThato.github.io/site/).
- Modified the GitHub Actions workflow (`.github/workflows/static.yml`):
    - Added a step to verify the build output by checking the contents of the `dist` directory.
    - Refined the "Prepare artifact directory" step for clarity and to ensure correct file placement for GitHub Pages deployment. This includes cleaning the artifact directory, copying `public/index.html` to the root, and `dist/bundle.js` to the `dist/` subfolder within the artifact. It also adds a step to show the final artifact structure for easier debugging from workflow logs.

These changes, combined with correct repository settings for GitHub Pages (serving from the `gh-pages` branch, root folder), should resolve the deployment issues.